### PR TITLE
Update name to accumulo2-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ See the [plugin documentation][plugin-docs] for more details.
 
 [accumulo]: https://accumulo.apache.org
 [Maven]: https://maven.apache.org
-[plugin-docs]: https://accumulo.apache.org/accumulo-maven-plugin
+[plugin-docs]: https://accumulo.apache.org/accumulo2-maven-plugin
 [li]: https://img.shields.io/badge/license-ASL-blue.svg
 [ll]: https://www.apache.org/licenses/LICENSE-2.0
-[mi]: https://maven-badges.herokuapp.com/maven-central/org.apache.accumulo/accumulo-maven-plugin/badge.svg
-[ml]: https://maven-badges.herokuapp.com/maven-central/org.apache.accumulo/accumulo-maven-plugin/
-[ji]: https://www.javadoc.io/badge/org.apache.accumulo/accumulo-maven-plugin.svg
-[jl]: https://www.javadoc.io/doc/org.apache.accumulo/accumulo-maven-plugin
+[mi]: https://maven-badges.herokuapp.com/maven-central/org.apache.accumulo/accumulo2-maven-plugin/badge.svg
+[ml]: https://maven-badges.herokuapp.com/maven-central/org.apache.accumulo/accumulo2-maven-plugin/
+[ji]: https://www.javadoc.io/badge/org.apache.accumulo/accumulo2-maven-plugin.svg
+[jl]: https://www.javadoc.io/doc/org.apache.accumulo/accumulo2-maven-plugin
 [ti]: https://travis-ci.org/apache/accumulo-maven-plugin.svg?branch=master
 [tl]: https://travis-ci.org/apache/accumulo-maven-plugin
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,14 +23,14 @@
     <version>21</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
-  <artifactId>accumulo-maven-plugin</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <artifactId>accumulo2-maven-plugin</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>Apache Accumulo Maven Plugin</name>
   <description>An Apache Maven plugin for testing software against a test Apache Accumulo instance.</description>
   <!-- this URL is where the site derived via the maven-site-plugin ends up,
        not the generic site; currently not used -->
-  <url>https://accumulo.apache.org/accumulo-maven-plugin</url>
+  <url>https://accumulo.apache.org/accumulo2-maven-plugin</url>
   <!-- this is the year of inception at ASF -->
   <inceptionYear>2013</inceptionYear>
   <organization>

--- a/src/it/plugin-test/pom.xml
+++ b/src/it/plugin-test/pom.xml
@@ -19,9 +19,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>@project.groupId@</groupId>
-    <artifactId>accumulo-project</artifactId>
-    <version>@accumulo.version@</version>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>21</version>
   </parent>
 
   <groupId>@project.groupId@</groupId>
@@ -30,71 +30,82 @@
 
   <description>A simple IT verifying the basic use case.</description>
 
-  <properties>
-    <warbucks.skip>true</warbucks.skip>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
     </dependency>
     <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-minicluster</artifactId>
+      <version>@accumulo.version@</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
+      <version>4.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
+      <version>2.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <version>3.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-api</artifactId>
+      <version>3.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
+      <version>3.4.14</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>1.7.26</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.26</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client-runtime</artifactId>
+      <version>3.1.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/plugin-test/postbuild.groovy
+++ b/src/it/plugin-test/postbuild.groovy
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-File outputDirectory = new File(basedir, "target/accumulo-maven-plugin/plugin-it-instance");
+File outputDirectory = new File(basedir, "target/accumulo2-maven-plugin/plugin-it-instance");
 assert outputDirectory.isDirectory()
 
-File testCreateTable = new File(basedir, "target/accumulo-maven-plugin/plugin-it-instance/testCreateTablePassed");
+File testCreateTable = new File(basedir, "target/accumulo2-maven-plugin/plugin-it-instance/testCreateTablePassed");
 assert testCreateTable.isFile()
 
-File testWriteToTable = new File(basedir, "target/accumulo-maven-plugin/plugin-it-instance/testWriteToTablePassed");
+File testWriteToTable = new File(basedir, "target/accumulo2-maven-plugin/plugin-it-instance/testWriteToTablePassed");
 assert testWriteToTable.isFile()
 
-File testCheckIterator = new File(basedir, "target/accumulo-maven-plugin/plugin-it-instance/testCheckIteratorPassed");
+File testCheckIterator = new File(basedir, "target/accumulo2-maven-plugin/plugin-it-instance/testCheckIteratorPassed");
 assert testCheckIterator.isFile()

--- a/src/it/plugin-test/src/test/java/org/apache/accumulo/plugin/it/PluginIT.java
+++ b/src/it/plugin-test/src/test/java/org/apache/accumulo/plugin/it/PluginIT.java
@@ -52,7 +52,7 @@ public class PluginIT {
   @BeforeClass
   public static void setUp() throws Exception {
     String instanceName = "plugin-it-instance";
-    props = MiniAccumuloCluster.getClientProperties(new File("target/accumulo-maven-plugin/" + instanceName));
+    props = MiniAccumuloCluster.getClientProperties(new File("target/accumulo2-maven-plugin/" + instanceName));
     client = Accumulo.newClient().from(props).build();
   }
 
@@ -68,7 +68,7 @@ public class PluginIT {
     String tableName = "testCreateTable";
     client.tableOperations().create(tableName);
     assertTrue(client.tableOperations().exists(tableName));
-    assertTrue(new File("target/accumulo-maven-plugin/" + props.getProperty("instance.name") + "/testCreateTablePassed").createNewFile());
+    assertTrue(new File("target/accumulo2-maven-plugin/" + props.getProperty("instance.name") + "/testCreateTablePassed").createNewFile());
   }
 
   @Test
@@ -90,7 +90,7 @@ public class PluginIT {
       assertEquals("V", entry.getValue().toString());
     }
     assertEquals(1, count);
-    assertTrue(new File("target/accumulo-maven-plugin/" + props.getProperty("instance.name") + "/testWriteToTablePassed").createNewFile());
+    assertTrue(new File("target/accumulo2-maven-plugin/" + props.getProperty("instance.name") + "/testWriteToTablePassed").createNewFile());
   }
 
   @Test
@@ -131,7 +131,7 @@ public class PluginIT {
       assertEquals("denied", entry.getKey().getColumnFamily().toString());
     }
     assertEquals(2, count);
-    assertTrue(new File("target/accumulo-maven-plugin/" + props.getProperty("instance.name") + "/testCheckIteratorPassed").createNewFile());
+    assertTrue(new File("target/accumulo2-maven-plugin/" + props.getProperty("instance.name") + "/testCheckIteratorPassed").createNewFile());
   }
 
 }

--- a/src/main/java/org/apache/accumulo/maven/plugin/AbstractAccumuloMojo.java
+++ b/src/main/java/org/apache/accumulo/maven/plugin/AbstractAccumuloMojo.java
@@ -35,7 +35,7 @@ public abstract class AbstractAccumuloMojo extends AbstractMojo {
 
   protected boolean shouldSkip() {
     if (skip) {
-      getLog().info("Skipping execution of accumulo-maven-plugin");
+      getLog().info("Skipping execution of accumulo2-maven-plugin");
     }
     return skip;
   }

--- a/src/main/java/org/apache/accumulo/maven/plugin/StartMojo.java
+++ b/src/main/java/org/apache/accumulo/maven/plugin/StartMojo.java
@@ -70,7 +70,7 @@ public class StartMojo extends AbstractAccumuloMojo {
       throw new MojoExecutionException("instanceName must be only letters and numbers");
     }
 
-    File subdir = new File(new File(outputDirectory, "accumulo-maven-plugin"), instanceName);
+    File subdir = new File(new File(outputDirectory, "accumulo2-maven-plugin"), instanceName);
     try {
       subdir = subdir.getCanonicalFile();
       if (subdir.exists())

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -17,8 +17,8 @@
 Description
 -----------
 
-  This `accumulo-maven-plugin` allows your Maven project to run a mini,
-  single node instance of Apache Accumulo in order for you to run your
+  This `accumulo2-maven-plugin` allows your Maven project to run a mini,
+  single node instance of Apache Accumulo 2.x in order for you to run your
   project's integration tests against a live version of Accumulo.
 
 Getting Started


### PR DESCRIPTION
Starting naming plugin according to supported major Accumulo version,
with its own versioning starting at 1.0.0